### PR TITLE
base: add sugar for inlining files

### DIFF
--- a/base/v0_1/schema.go
+++ b/base/v0_1/schema.go
@@ -65,6 +65,7 @@ type File struct {
 type FileContents struct {
 	Compression  *string      `yaml:"compression"`
 	Source       *string      `yaml:"source"`
+	Inline       *string      `yaml:"inline"` // Added, not in ignition spec
 	Verification Verification `yaml:"verification"`
 }
 

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -57,7 +57,7 @@ func TestTranslateFile(t *testing.T) {
 						},
 					},
 					{
-						Source:      util.StrToPtr("http://example/com"),
+						Inline:      util.StrToPtr("hello"),
 						Compression: util.StrToPtr("gzip"),
 						Verification: Verification{
 							Hash: util.StrToPtr("this isn't validated"),
@@ -97,7 +97,7 @@ func TestTranslateFile(t *testing.T) {
 							},
 						},
 						{
-							Source:      util.StrToPtr("http://example/com"),
+							Source:      util.StrToPtr("data:,hello"),
 							Compression: util.StrToPtr("gzip"),
 							Verification: types.Verification{
 								Hash: util.StrToPtr("this isn't validated"),

--- a/base/v0_1/validate.go
+++ b/base/v0_1/validate.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_1
+
+import (
+	"errors"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	ErrInlineAndSource = errors.New("inline cannot be specified if source is specified")
+)
+
+func (f FileContents) Validate(c path.ContextPath) (r report.Report) {
+	if f.Inline != nil && f.Source != nil {
+		r.AddOnError(c.Append("inline"), ErrInlineAndSource)
+	}
+	return
+}

--- a/base/v0_1/validate_test.go
+++ b/base/v0_1/validate_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+// TestValidateFileContents tests that multiple sources (i.e. urls and inline) are not allowed but zero or one sources are
+func TestValidateFileContents(t *testing.T) {
+	tests := []struct {
+		in  FileContents
+		out error
+	}{
+		{},
+		{
+			// contains invalid (by the validator's definition) combinations of fields,
+			// but the translator doesn't care and we can check they all get translated at once
+			FileContents{
+				Source:      util.StrToPtr("http://example/com"),
+				Compression: util.StrToPtr("gzip"),
+				Verification: Verification{
+					Hash: util.StrToPtr("this isn't validated"),
+				},
+			},
+			nil,
+		},
+		{
+			FileContents{
+				Inline:      util.StrToPtr("hello"),
+				Compression: util.StrToPtr("gzip"),
+				Verification: Verification{
+					Hash: util.StrToPtr("this isn't validated"),
+				},
+			},
+			nil,
+		},
+		{
+			FileContents{
+				Source:      util.StrToPtr("data:,hello"),
+				Inline:      util.StrToPtr("hello"),
+				Compression: util.StrToPtr("gzip"),
+				Verification: Verification{
+					Hash: util.StrToPtr("this isn't validated"),
+				},
+			},
+			ErrInlineAndSource,
+		},
+	}
+
+	for i, test := range tests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		// hardcode inline for now since that's the only place errors occur. Move into the
+		// test struct once there's more than one place
+		expected.AddOnError(path.New("yaml", "inline"), test.out)
+
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("#%d: expected %+v got %+v", i, expected, actual)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/coreos/ignition/v2 v2.0.0
 	github.com/coreos/vcontext v0.0.0-20190605182717-e9c4ffaa1f6a
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )


### PR DESCRIPTION
Add a field storage.files.contents.inline in addition to the existing
"source" field. "inline" is mutually exclusive with "source".